### PR TITLE
cr_checker: add the 1st version of tool.

### DIFF
--- a/modules/cr_checker/0.1.0/MODULE.bazel
+++ b/modules/cr_checker/0.1.0/MODULE.bazel
@@ -1,0 +1,41 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+module(
+    name = "cr_checker",
+    version = "0.1.0",
+    compatibility_level = 0,
+)
+
+###############################################################################
+#
+# Python version
+#
+###############################################################################
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+PYTHON_VERSION = "3.12"
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    is_default = True,
+    python_version = PYTHON_VERSION,
+)
+use_repo(python)
+
+###############################################################################
+#
+# Generic linting and formatting rules
+#
+###############################################################################
+bazel_dep(name = "aspect_rules_py", version = "1.0.0")

--- a/modules/cr_checker/0.1.0/source.json
+++ b/modules/cr_checker/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-3ea251bf8407d06267ccdb5b731537824b396aeb",
+    "patch_strip": 1,
+    "url": "https://github.com/eclipse-score/tooling.git"
+}

--- a/modules/cr_checker/metadata.json
+++ b/modules/cr_checker/metadata.json
@@ -1,0 +1,13 @@
+{
+    "homepage": "https://github.com/nradakovic/tooling/cr_checker",
+    "maintainers": [
+        {
+            "email": "nikola.ra.radakovic@bmw.de",
+            "github": "nradakovic",
+            "name": "Nikola Radakovic"
+        }
+    ],
+    "versions": [
+        "0.1.0"
+    ]
+}


### PR DESCRIPTION
Add the first version of cr_checker to private Bazel registry on S-CORE project.