### PR TITLE
Add CopyRight Checker into S-CORE Bazel Registry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# S-CORE Bazel Registry (SBR) contribution guidelines
+
+TBD!

--- a/modules/score_cr_checker/0.2.0/MODULE.bazel
+++ b/modules/score_cr_checker/0.2.0/MODULE.bazel
@@ -1,0 +1,41 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+module(
+    name = "score_cr_checker",
+    version = "0.2.0",
+    compatibility_level = 0,
+)
+
+###############################################################################
+#
+# Python version
+#
+###############################################################################
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+PYTHON_VERSION = "3.12"
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    is_default = True,
+    python_version = PYTHON_VERSION,
+)
+use_repo(python)
+
+###############################################################################
+#
+# Generic linting and formatting rules
+#
+###############################################################################
+bazel_dep(name = "aspect_rules_py", version = "1.0.0")

--- a/modules/score_cr_checker/0.2.0/source.json
+++ b/modules/score_cr_checker/0.2.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-",
+    "strip_prefix": "tooling-release-0.0.2/cr_checker",
+    "url": "https://github.com/eclipse-score/tooling/archive/refs/tags/release-0.0.2.tar.gz"
+}

--- a/modules/score_cr_checker/metadata.json
+++ b/modules/score_cr_checker/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/eclipse-score/tooling",
+    "maintainers": [
+        {
+            "name": "Nikola Radakovic",
+            "email": "nikola.ra.radakovic@bmw.de",
+            "github": "nradakovic"
+        }
+    ],
+    "repository": [
+        "github:eclipse-score/tooling"
+    ],
+    "versions": [
+        "0.1.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
CopyRight checker is one of eclipse-score host tools that needs to be deployed in all modules under S-CORE and as such has to be part of internal bazel registry (SBR - S-CORE Bazel Registry).