### PR TITLE
cr_checker: Fix the metadata version number

### DIFF
--- a/modules/score_cr_checker/metadata.json
+++ b/modules/score_cr_checker/metadata.json
@@ -11,7 +11,7 @@
         "github:eclipse-score/tooling"
     ],
     "versions": [
-        "0.1.1"
+        "0.2.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
The current set version in metadata file is wrong. This commit set the correct version number.

Issue-Ref: #8 