### PR TITLE
dash: added to registry

### DIFF
--- a/modules/dash_license_checker/0.1.0/MODULE.bazel
+++ b/modules/dash_license_checker/0.1.0/MODULE.bazel
@@ -1,0 +1,34 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+module(
+    name = "dash_license_checker",
+    version = "0.1.0",
+    compatibility_level = 0,
+)
+
+# dependency on rules_java.
+bazel_dep(name = "rules_java", version = "5.0.0") 
+
+
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+DASH_VERSION = "1.1.0"
+
+http_jar(
+    name = "dash_license_tool",
+    sha256 = "ba4e84e1981f0e51f92a42ec8fc8b9668dabb08d1279afde46b8414e11752b06",
+    urls = [
+        "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/{version}/org.eclipse.dash.licenses-{version}.jar".format(version = DASH_VERSION),
+    ],
+)

--- a/modules/dash_license_checker/0.1.0/source.json
+++ b/modules/dash_license_checker/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-Klht6Jszq7G35ZOm4MJbDRdlutic8RGSXDpoLxx0o/o=",
+    "strip_prefix": "tooling-release-0.3.0/dash",
+    "url": "https://github.com/eclipse-score/tooling/archive/refs/tags/release-0.3.0.tar.gz"
+}

--- a/modules/dash_license_checker/metadata.json
+++ b/modules/dash_license_checker/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/eclipse-score/tooling",
+    "maintainers": [
+        {
+            "name": "Nikola Radakovic",
+            "email": "nikola.ra.radakovic@bmw.de",
+            "github": "nradakovic"
+        }
+    ],
+    "repository": [
+        "github:eclipse-score/tooling"
+    ],
+    "versions": [
+        "0.2.0",
+        "0.2.1"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/dash_license_checker/metadata.json
+++ b/modules/dash_license_checker/metadata.json
@@ -5,14 +5,18 @@
             "name": "Nikola Radakovic",
             "email": "nikola.ra.radakovic@bmw.de",
             "github": "nradakovic"
-        }
+        },
+        {
+            "name": "Dan Calavrezo",
+            "email": "danc_ext@qorix.ai",
+            "github": "dcalavrezo-qorix"
+        }        
     ],
     "repository": [
         "github:eclipse-score/tooling"
     ],
     "versions": [
-        "0.2.0",
-        "0.2.1"
+        "0.1.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Added the dash_license_check module to our bazel_registry

Why MODULE.bazel is needed in the registry?
Bazel's module registry format defines how to bootstrap a module when it's being fetched. When you register a module in your local or remote registry, Bazel does not extract the MODULE.bazel from the tarball by default.

Instead, it expects this structure in your registry:

```
modules/
  dash_license_checker/
    0.1.0/
      MODULE.bazel     <- Required in the registry for this version
      source.json
      metadata.json
```

This MODULE.bazel:

Overrides what may exist in the archive (tarball).

Ensures consistent resolution and setup regardless of upstream source layout.

Is used by Bazel's BCR tooling and other consumers of the Bazel Registry protocol.

Addresses #505