### PR TITLE
dash: embedded the JAR

### DIFF
--- a/modules/dash_license_checker/0.1.0/MODULE.bazel
+++ b/modules/dash_license_checker/0.1.0/MODULE.bazel
@@ -17,18 +17,5 @@ module(
     compatibility_level = 0,
 )
 
-# dependency on rules_java.
+# dependency on rules_java
 bazel_dep(name = "rules_java", version = "8.6.3")
-
-
-http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
-
-DASH_VERSION = "1.1.0"
-
-http_jar(
-    name = "dash_license_tool",
-    sha256 = "ba4e84e1981f0e51f92a42ec8fc8b9668dabb08d1279afde46b8414e11752b06",
-    urls = [
-        "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/{version}/org.eclipse.dash.licenses-{version}.jar".format(version = DASH_VERSION),
-    ],
-)

--- a/modules/dash_license_checker/0.1.0/source.json
+++ b/modules/dash_license_checker/0.1.0/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-Klht6Jszq7G35ZOm4MJbDRdlutic8RGSXDpoLxx0o/o=",
-    "strip_prefix": "tooling-release-0.3.0/dash",
-    "url": "https://github.com/eclipse-score/tooling/archive/refs/tags/release-0.3.0.tar.gz"
+    "integrity": "sha256-xm87iMEQGbwfbx+fZjRPWEW19NZ6teNnvRUi0WuKJIQ=",
+    "strip_prefix": "tooling-release-0.3.1/dash",
+    "url": "https://github.com/eclipse-score/tooling/archive/refs/tags/release-0.3.1.tar.gz"
 }


### PR DESCRIPTION
update the dash tool, incorporated the DASH license tool to make it easily usable by consumer repos

Addresses: eclipse-score/score#505