### PR TITLE
Add GNU GCC toolchain rules to SBR

### DIFF
--- a/modules/score_toolchains_gcc/0.1/MODULE.bazel
+++ b/modules/score_toolchains_gcc/0.1/MODULE.bazel
@@ -1,0 +1,39 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+module(
+    name = "score_toolchains_gcc",
+    version = "0.1",
+    compatibility_level = 0,
+)
+
+#############################################################
+#
+# Common useful functions and rules for Bazel
+#
+#############################################################
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+#############################################################
+#
+# Constraint values for specifying platforms and toolchains
+#
+#############################################################
+bazel_dep(name = "platforms", version = "0.0.10")
+
+#############################################################
+#
+# C++ Rules for Bazel
+#
+#############################################################
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/score_toolchains_gcc/0.1/source.json
+++ b/modules/score_toolchains_gcc/0.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-iWGU39AIKxnRjIgANcwxBVhalzGFnePWR+5zmN5hfIg=",
+    "strip_prefix": "toolchains_gcc-0.0.2/bazel",
+    "url": "https://github.com/eclipse-score/toolchains_gcc/archive/refs/tags/0.0.2.tar.gz"
+}

--- a/modules/score_toolchains_gcc/metadata.json
+++ b/modules/score_toolchains_gcc/metadata.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/eclipse-score/toolchain_gcc",
+    "maintainers": [
+        {
+            "name": "Nikola Radakovic",
+            "email": "nikola.ra.radakovic@bmw.de",
+            "github": "nradakovic"
+        },
+        {
+            "name": "Lukasz Tekieli",
+            "email": "lukasz.tekieli@bmw.de",
+            "github": "ltekieli"
+        }
+    ],
+    "repository": [
+        "github:eclipse-score/toolchain_gcc"
+    ],
+    "versions": [
+        "0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
The following GNU GCC toolchain will be used for host build on S-CORE modules.