### PR TITLE
bug: missing target

### DIFF
--- a/modules/score_dash_license_checker/0.1.1/source.json
+++ b/modules/score_dash_license_checker/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-2G25RAb7VHzpzwuGTy+PrmiR5eYyPE895vW/KVFFq2k=",
-    "strip_prefix": "tooling-release-0.6.1/dash",
-    "url": "https://github.com/eclipse-score/tooling/archive/refs/tags/release-0.6.1.tar.gz"
+    "integrity": "sha256-3x1LMPG3Q7/AxEUW7QX22yZQWLPLHF/vQvQUvm6U5IQ=",
+    "strip_prefix": "tooling-release-0.6.2/dash",
+    "url": "https://github.com/eclipse-score/tooling/archive/refs/tags/release-0.6.2.tar.gz"
 }


### PR DESCRIPTION
A target was forgotten.
Tested locally and properly this time using

```
common --registry=file:///home/dcalavrezo/sources/bazel_registry
```

Addresses: eclispe-score/score#922