### PR TITLE
Add new version of score_toolchains_gcc

### DIFF
--- a/modules/score_cr_checker/0.2.2/MODULE.bazel
+++ b/modules/score_cr_checker/0.2.2/MODULE.bazel
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/modules/score_toolchains_gcc/0.2/MODULE.bazel
+++ b/modules/score_toolchains_gcc/0.2/MODULE.bazel
@@ -1,0 +1,39 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+module(
+    name = "score_toolchains_gcc",
+    version = "0.2",
+    compatibility_level = 0,
+)
+
+#############################################################
+#
+# Common useful functions and rules for Bazel
+#
+#############################################################
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+#############################################################
+#
+# Constraint values for specifying platforms and toolchains
+#
+#############################################################
+bazel_dep(name = "platforms", version = "0.0.10")
+
+#############################################################
+#
+# C++ Rules for Bazel
+#
+#############################################################
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/score_toolchains_gcc/0.2/source.json
+++ b/modules/score_toolchains_gcc/0.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-b2P8NojvYX8VWgI1sl4J9BGYJZRQQFogyNP/jkksavc=",
+    "strip_prefix": "toolchains_gcc-0.0.3/",
+    "url": "https://github.com/eclipse-score/toolchains_gcc/archive/refs/tags/0.0.3.tar.gz"
+}

--- a/modules/score_toolchains_gcc/metadata.json
+++ b/modules/score_toolchains_gcc/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/eclipse-score/toolchain_gcc",
+    "homepage": "https://github.com/eclipse-score/toolchains_gcc",
     "maintainers": [
         {
             "name": "Nikola Radakovic",
@@ -15,10 +15,11 @@
         }
     ],
     "repository": [
-        "github:eclipse-score/toolchain_gcc"
+        "github:eclipse-score/toolchains_gcc"
     ],
     "versions": [
-        "0.1"
+        "0.1",
+        "0.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
The new version of score_toolchains_gcc brings in support for dependencies imported over WORKSPACE file.