### PR TITLE
Replace compatibility_level check with semver-based validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  verify:
+  verify_registry:
     runs-on: ubuntu-latest
     name: "🔍 Verify Registry"
     steps:
@@ -12,8 +12,40 @@ jobs:
         uses: actions/checkout@v4
       - name: 📦 Setup Bazel
         uses: bazel-contrib/setup-bazel@0.9.1
+
+      - name: Cross-Check SemVer with compatibility_level
+        run: |
+          bazel run //tools:ide_support
+          .venv/bin/python tools/verify_semver_compatibility_level.py
+
       - name: Run verification script
         run: bazel run //tools:verify_modules
+
+  verify_self:
+    runs-on: ubuntu-latest
+    name: "🔍 Self Test"
+    steps:
+      - name: "🔄 Check out"
+        uses: actions/checkout@v4
+      - name: 📦 Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.9.1
+
+      - name: Run pytest
+        run: |
+          bazel run //tools:ide_support
+          .venv/bin/python -m pytest tools
+
+  verify_self_fast:
+    runs-on: ubuntu-latest
+    name: "🔍 Self Test (Fast)"
+    steps:
+      - name: "🔄 Check out"
+        uses: actions/checkout@v4
+
+      - name: Run pytest
+        run: |
+          pip install -r tools/requirements.txt
+          pytest tools
 
   copyright-check:
     uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@main

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  // Run only on tools to avoid going into bazel-generated files
+  "python.testing.pytestArgs": [
+    "tools"
+  ],
+  // Enable pytest as the testing framework
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,12 @@
 [tool.pyright]
 extends = "bazel-bin/tools/ide_support.runfiles/_main/external/score_python_basics~/pyproject.toml"
 
+exclude = [
+    "**/__pycache__",
+    "**/.*",
+    "**/bazel-*",
+]
+
 [tool.ruff]
 extend = "bazel-bin/tools/ide_support.runfiles/_main/external/score_python_basics~/pyproject.toml"
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,12 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************

--- a/tools/requirements.in
+++ b/tools/requirements.in
@@ -4,3 +4,6 @@ jsonschema
 pyyaml
 requests
 packaging
+
+# needed by test_verify_semver_compatibility_level.py
+pyfakefs

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -115,7 +115,7 @@ idna==3.10 \
 jsonschema==4.23.0 \
     --hash=sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4 \
     --hash=sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566
-    # via -r requirements.in
+    # via -r tools/requirements.in
 jsonschema-specifications==2024.10.1 \
     --hash=sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272 \
     --hash=sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf
@@ -123,7 +123,11 @@ jsonschema-specifications==2024.10.1 \
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
-    # via -r requirements.in
+    # via -r tools/requirements.in
+pyfakefs==5.8.0 \
+    --hash=sha256:4bd0fc8def7d0582139922447758632ff34a327b460a7e83feb6edbd841061dd \
+    --hash=sha256:7e5457ee3cc67069d3cef6e278227ecfc80bfb61e925bc0a4d3b0af32d1c99ce
+    # via -r tools/requirements.in
 pyyaml==6.0.2 \
     --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
     --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
@@ -178,7 +182,7 @@ pyyaml==6.0.2 \
     --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
-    # via -r requirements.in
+    # via -r tools/requirements.in
 referencing==0.36.2 \
     --hash=sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa \
     --hash=sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0
@@ -188,7 +192,7 @@ referencing==0.36.2 \
 requests==2.32.4 \
     --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
     --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
-    # via -r requirements.in
+    # via -r tools/requirements.in
 rpds-py==0.24.0 \
     --hash=sha256:0047638c3aa0dbcd0ab99ed1e549bbf0e142c9ecc173b6492868432d8989a046 \
     --hash=sha256:006f4342fe729a368c6df36578d7a348c7c716be1da0a1a0f86e3021f8e98724 \

--- a/tools/test_verify_semver_compatibility_level.py
+++ b/tools/test_verify_semver_compatibility_level.py
@@ -1,0 +1,75 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+import json
+from pathlib import Path
+from typing import Any
+
+from .verify_semver_compatibility_level import analyze
+
+
+def build_fake_filesystem(fs: Any, structure: dict[str, object], base_path: str = ""):
+    """See examples below to understand the dict structure."""
+    for name, value in structure.items():
+        path = f"{base_path}/{name}"
+        if isinstance(value, dict):
+            fs.makedirs(path, exist_ok=True)
+            build_fake_filesystem(fs, value, path)
+        else:
+            fs.create_file(path, contents=value)
+
+
+def test_all_correct(fs: Any):
+    """When all modules have compatibility_level matching major version, all is well."""
+    build_fake_filesystem(fs, {
+        "modules": {
+            "a_correct_module": {
+                "metadata.json": '{"versions": ["1.0.0", "2.0.0"]}',
+                "1.0.0": {"MODULE.bazel": "module(name='a_correct_module', version='1.0.0', compatibility_level=1)\n"},
+                "2.0.0": {"MODULE.bazel": "module(name='a_correct_module', version='2.0.0', compatibility_level=2)\n"},
+            }
+        }
+    })
+    results = analyze(Path("/modules"))
+    assert results[0].type == "ok"
+    assert results[1].type == "ok"
+    assert len(results) == 2
+
+
+def test_missing_level(fs: Any):
+    """Missing compatibility_level should not fail, but warn."""
+    build_fake_filesystem(fs, {
+        "modules": {
+            "bar": {
+                "metadata.json": json.dumps({"versions": ["1.0.0"]}),
+                "1.0.0": {"MODULE.bazel": "module(name='bar', version='1.0.0')\n"},
+            }
+        }
+    })
+    results = analyze(Path("/modules"))
+    assert results[0].type == "warning"
+    assert len(results) == 1
+
+
+def test_wrong_level(fs: Any):
+    """When compatibility_level does not match major version, it should fail."""
+    build_fake_filesystem(fs, {
+        "modules": {
+            "a_wrong_module": {
+                "metadata.json": '{"versions": ["1.0.0"]}',
+                "1.0.0": {"MODULE.bazel": "module(name='a_wrong_module', version='1.0.0', compatibility_level=2)\n"},
+            }
+        }
+    })
+    results = analyze(Path("/modules"))
+    assert results[0].type == "error"
+    assert len(results) == 1

--- a/tools/verify_semver_compatibility_level.py
+++ b/tools/verify_semver_compatibility_level.py
@@ -1,0 +1,148 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Purpose:
+    This registry uses semantic versioning (semver), but Bazel itself does not
+    interpret version numbers as semver. Instead, Bazel relies on the
+    `compatibility_level` field to determine breaking changes and module
+    compatibility. This script ensures that every module version in the registry
+    has a `compatibility_level` in its `MODULE.bazel` file matching the major
+    version of the module. This alignment enforces semver expectations for users
+    and Bazel tooling, helping maintainers and users avoid surprises and enforce
+    good versioning practices.
+"""
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+GIT_ROOT = Path(__file__).parent.parent
+MODULES_DIR = GIT_ROOT / 'modules'
+
+
+def extract_major_version(version: str):
+    """
+    Extract the major version number from a version string (e.g., '2.1.0' -> 2).
+    """
+    return int(version.split('.')[0])
+
+
+def parse_compatibility_level(module_bazel_path: Path):
+    """
+    Parse the compatibility_level integer from a MODULE.bazel file.
+    Returns None if not found.
+    """
+    content = module_bazel_path.read_text()
+    m = re.search(r'compatibility_level\s*=\s*(\d+)', content)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def is_github_actions():
+    """
+    Return True if running in a GitHub Actions environment.
+    """
+    return "GITHUB_ACTIONS" in os.environ
+
+
+@dataclass
+class CheckResult:
+    type: str  # 'ok', 'warning', 'error'
+    file: Path
+    msg: str
+    line: int = 1
+
+
+def analyze(modules_dir: Path) -> list[CheckResult]:
+    """
+    For each module and each version listed in its metadata.json, check that
+    the MODULE.bazel file contains a compatibility_level matching the major
+    version. Returns a list of CheckResult objects for reporting.
+    """
+    results: list[CheckResult] = []
+    for module in modules_dir.iterdir():
+        meta_path = module / 'metadata.json'
+        with meta_path.open() as f:
+            meta: dict[str, object] = json.load(f)
+        versions = meta.get('versions', [])
+        assert isinstance(versions, list), "Versions should be a list"
+        for version in versions:
+            assert isinstance(version, str), "Version should be a string"
+            mod_bazel = module / version / 'MODULE.bazel'
+            major = extract_major_version(version)
+            compatibility_level = parse_compatibility_level(mod_bazel)
+            if compatibility_level is None:
+                results.append(CheckResult(
+                    type='warning',
+                    file=mod_bazel,
+                    msg='missing compatibility_level',
+                ))
+            elif compatibility_level != major:
+                results.append(CheckResult(
+                    type='error',
+                    file=mod_bazel,
+                    msg=f'compatibility_level {compatibility_level} does not match '
+                    f'major version {major} (from version {version})',
+                ))
+            else:
+                results.append(CheckResult(
+                    type='ok',
+                    file=mod_bazel,
+                    msg=f'compatibility_level {compatibility_level} matches '
+                    f'major version {major}',
+                ))
+    return results
+
+
+def print_results(results: list[CheckResult], gha: bool):
+    """
+    Print the results of the compatibility check. Formats output for local
+    runs or GitHub Actions as appropriate.
+    """
+    for r in results:
+        file = r.file.relative_to(GIT_ROOT)
+        if r.type == 'ok':
+            if not gha:
+                print(f"✅ OK: {file} {r.msg}")
+        elif r.type == 'warning':
+            if gha:
+                print(f"::error file={file},line={r.line}::{r.msg}")
+            else:
+                print(f"⚠️ WARNING: {file} {r.msg}")
+        elif r.type == 'error':
+            if gha:
+                print(f"::error file={file},line={r.line}::{r.msg}")
+            else:
+                print(f"❌ ERROR: {file} {r.msg}")
+
+
+if __name__ == '__main__':
+    results = analyze(MODULES_DIR)
+    gha = is_github_actions()
+
+    print_results(results, gha)
+
+    any_error = any(r.type == 'error' for r in results)
+    if any_error:
+        if not gha:
+            print("\n❌ Some modules have incorrect compatibility_level.")
+        sys.exit(1)
+    else:
+        if not gha:
+            print("\n✅ All modules have correct compatibility_level.")
+        sys.exit(0)


### PR DESCRIPTION
This change adds a script to enforce that each module version's compatibility_level matches its semver major version.
Previously, changing compatibility_level between releases resulted in errors (see #60).
This PR fully replaces the old compatibility_level check with a semver-aligned approach, ensuring consistency and reducing confusion for maintainers and users.