### PR TITLE
Fix automated pull request creation for module updates

### DIFF
--- a/.github/workflows/check_new_releases.yml
+++ b/.github/workflows/check_new_releases.yml
@@ -47,3 +47,10 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           title: Update modules
+          author: score-automations[bot] <score-bot@users.noreply.github.com>
+          body: |
+            This PR updates the modules to their latest versions.
+            Please review and merge if everything looks good.
+          commit-message: Update modules
+          # We need to use a different token than GITHUB_TOKEN, so that PR triggers all the PR-workflows.
+          token: ${{ secrets.SCORE_BOT_PAT }}


### PR DESCRIPTION
We need to use a different token than GITHUB_TOKEN, so that automated PRs trigger our PR-workflows.