### PR TITLE
Add score Bazel platform module

### DIFF
--- a/modules/score_bazel_platforms/0.0.1/MODULE.bazel
+++ b/modules/score_bazel_platforms/0.0.1/MODULE.bazel
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+""" This module contains the global definitions of constraint_settings, constraint_values and platforms.
+"""
+
+module(
+    name = "score_bazel_platforms",
+    version = "0.0.1",
+    compatibility_level = 0,
+)
+
+#############################################################
+#
+# Constraint values for specifying platforms and toolchains
+#
+#############################################################
+bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/score_bazel_platforms/0.0.1/source.json
+++ b/modules/score_bazel_platforms/0.0.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-w6hQ8PFC7UcHfC94Tv+HtLC+GFXqbl45vUA7gzadHRQ=",
+    "strip_prefix": "bazel_platforms-0.0.1",
+    "url": "https://github.com/eclipse-score/bazel_platforms/archive/refs/tags/v0.0.1.tar.gz"
+}

--- a/modules/score_bazel_platforms/metadata.json
+++ b/modules/score_bazel_platforms/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/eclipse-score/bazel_platforms",
+    "maintainers": [
+        {
+            "name": "Nikola Radakovic",
+            "email": "nikola.ra.radakovic@bmw.de",
+            "github": "nradakovic",
+            "github_user_id": 35235060
+        }
+    ],
+    "repository": [
+        "github:eclipse-score/bazel_platforms"
+    ],
+    "versions": [
+        "0.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add S-CORE Bazel Platforms module in S-CORE Bazel Registry. This module hold base Bazel platfom definitions that other modules can and should reuse.