### PR TITLE
Include only newer versions to bazel_registry

### DIFF
--- a/scripts/check_and_update_modules.py
+++ b/scripts/check_and_update_modules.py
@@ -128,7 +128,7 @@ def enrich_modules(
 
         releases = get_all_releases(module_url, github_token)
 
-        # Process only the N oldest releases that are not yet added
+        # Process only the N newest releases that are not yet added
         count = 0
         for release in releases:
             # Do not add versions that are older than the current version.


### PR DESCRIPTION
* Code slightly refactored to use a dataclass
* Code will only add versions that are newer than the latest version already in bazel_registry

Bug occurrence example: https://github.com/eclipse-score/bazel_registry/pull/158/files#diff-252e4a7bd7117cadebc0d79943835564470757b0ebff149e4e0be4a0d43f59b4