### PR TITLE
Adds score_logging v0.2.0 to bazel registry

### DIFF
--- a/modules/score_logging/0.2.0/MODULE.bazel
+++ b/modules/score_logging/0.2.0/MODULE.bazel
@@ -1,0 +1,105 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+module(
+    name = "score_logging",
+    version = "0.2.0",
+    compatibility_level = 0,
+)
+
+# Bazel global rules
+bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_rust", version = "0.68.1-score")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "aspect_rules_lint", version = "1.0.3")
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# S-CORE process rules
+bazel_dep(name = "score_bazel_platforms", version = "0.1.2")
+bazel_dep(name = "score_docs_as_code", version = "4.0.1")
+single_version_override(
+    module_name = "score_docs_as_code",
+    version = "4.0.1",
+)
+
+bazel_dep(name = "score_tooling", version = "1.1.2")
+bazel_dep(name = "score_rust_policies", version = "0.0.3")
+
+bazel_dep(name = "score_process", version = "1.5.4", dev_dependency = True)
+bazel_dep(name = "score_platform", version = "0.5.5", dev_dependency = True)
+
+# Toolchains and extensions
+bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.1", dev_dependency = True)
+bazel_dep(name = "score_toolchains_rust", version = "0.8.0", dev_dependency = True)
+
+# S-CORE crates
+bazel_dep(name = "score_crates", version = "0.0.6")
+
+# TRLC dependency for requirements traceability
+bazel_dep(name = "trlc", version = "0.0.0", dev_dependency = True)
+git_override(
+    module_name = "trlc",
+    commit = "650b51a47264a4f232b3341f473527710fc32669",  # trlc-2.0.2 release
+    remote = "https://github.com/bmw-software-engineering/trlc.git",
+)
+
+gcc = use_extension("@score_bazel_cpp_toolchains//extensions:gcc.bzl", "gcc", dev_dependency = True)
+gcc.toolchain(
+    name = "score_qcc_aarch64_toolchain",
+    sdp_version = "8.0.0",
+    target_cpu = "aarch64",
+    target_os = "qnx",
+    use_default_package = True,
+    version = "12.2.0",
+)
+gcc.toolchain(
+    name = "score_gcc_x86_64_toolchain",
+    target_cpu = "x86_64",
+    target_os = "linux",
+    use_default_package = True,
+    version = "12.2.0",
+)
+gcc.toolchain(
+    name = "score_qcc_x86_64_toolchain",
+    sdp_version = "8.0.0",
+    target_cpu = "x86_64",
+    target_os = "qnx",
+    use_default_package = True,
+    version = "12.2.0",
+)
+use_repo(
+    gcc,
+    "score_gcc_x86_64_toolchain",
+    "score_qcc_aarch64_toolchain",
+    "score_qcc_x86_64_toolchain",
+)
+
+PYTHON_VERSION = "3.12"
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+python.toolchain(
+    is_default = True,
+    python_version = PYTHON_VERSION,
+)
+
+# C++ dependencies
+
+bazel_dep(name = "googletest", version = "1.17.0.bcr.1")
+bazel_dep(name = "rapidjson", version = "1.1.0")
+bazel_dep(name = "score_baselibs", version = "0.2.7")
+bazel_dep(name = "score_communication", version = "0.2.1")
+
+# Rust dependencies
+
+bazel_dep(name = "score_baselibs_rust", version = "0.1.0")

--- a/modules/score_logging/0.2.0/patches/module_dot_bazel_version.patch
+++ b/modules/score_logging/0.2.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,11 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -12,7 +12,7 @@
+ # *******************************************************************************
+ module(
+     name = "score_logging",
+-    version = "0.0.0",
++    version = "0.2.0",
+     compatibility_level = 0,
+ )
+

--- a/modules/score_logging/0.2.0/source.json
+++ b/modules/score_logging/0.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-/Q5+YfLkbMpz5PfvOkNS7qA3ehzth4emFhTcsk4q3zQ=",
+    "strip_prefix": "logging-0.2.0",
+    "url": "https://github.com/eclipse-score/logging/archive/refs/tags/v0.2.0.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-fxcyKHoG4Vkk/kUU8AuU1cbqDouj6lySmG2GyJP0gzo="
+    }
+}


### PR DESCRIPTION
Adds score_logging v0.2.0 to bazel registry

score_logging release: https://github.com/eclipse-score/logging/releases/tag/v0.2.0