### PR TITLE
fix persistency tarball hash

### DIFF
--- a/modules/score_persistency/0.3.1/source.json
+++ b/modules/score_persistency/0.3.1/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-+FKlYgGA1mZCgLwVCaFtrfio9QTv/je8WaZc2kAqAOU=",
+    "integrity": "sha256-z6UR+w5j8kqMtSctnq/t6aBTuthUedh/akYvoToDmRw=",
     "strip_prefix": "persistency-0.3.1",
     "url": "https://github.com/eclipse-score/persistency/archive/refs/tags/v0.3.1.tar.gz",
     "patch_strip": 1,


### PR DESCRIPTION
Release v0.3.1 has been recreated with the same name when previous version was already in bazel_registry.
Due to that old hash is present and needs to be fixed with recalculated one to match new tarball.