### PR TITLE
Revert "feat: push module updates directly to main instead of creating PRs"

### DIFF
--- a/.github/workflows/check_new_releases.yml
+++ b/.github/workflows/check_new_releases.yml
@@ -34,6 +34,7 @@ jobs:
     # permissions must be set even when using a PAT
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: 🛡️ Harden Runner
@@ -89,14 +90,15 @@ jobs:
           set -eu
           uv run registry-manager --format github_output ${{ github.event.inputs.module }} >> "$GITHUB_OUTPUT"
 
-      - name: 📤 Push to main
+      - name: 📤 Create Pull Request
         if: steps.registry_manager.outputs.has_updates == 'true'
-        run: |
-          git config user.name "eclipse-score-bot"
-          git config user.email "187756813+eclipse-score-bot@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${SCORE_BOT_CLASSIC_PAT}@github.com/${{ github.repository }}.git"
-          git add -A
-          git commit -m "${{ steps.registry_manager.outputs.commit_msg }}"
-          git push origin HEAD:main
-        env:
-          SCORE_BOT_CLASSIC_PAT: ${{ secrets.SCORE_BOT_CLASSIC_PAT }}
+        uses: peter-evans/create-pull-request@v8
+        with:
+          title: ${{ steps.registry_manager.outputs.pr_title }}
+          author: eclipse-score-bot <187756813+eclipse-score-bot@users.noreply.github.com>
+          body: ${{ steps.registry_manager.outputs.pr_body }}
+          commit-message: ${{ steps.registry_manager.outputs.commit_msg }}
+          base: main
+          branch: bot/modules-update
+          token: ${{ secrets.SCORE_BOT_CLASSIC_PAT }} # PAT belongs to eclipse-score-bot
+          labels: automation


### PR DESCRIPTION
Revert #442 which reverted #422 which reverted #412 :-)

Reason: otterdog change was merged. But due to some sync error it was never applied. There is a mismatch between config and live settings.