### PR TITLE
fix: point score_process and score_platform homepage to GitHub repo (fixes Renovate release notes)

### DIFF
--- a/modules/score_platform/metadata.json
+++ b/modules/score_platform/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://eclipse-score.github.io/score/",
+    "homepage": "https://github.com/eclipse-score/score",
     "periodic-pull": true,
     "maintainers": [
         {

--- a/modules/score_process/metadata.json
+++ b/modules/score_process/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://eclipse-score.github.io/process_description",
+    "homepage": "https://github.com/eclipse-score/process_description",
     "periodic-pull": true,
     "maintainers": [
         {


### PR DESCRIPTION
## Why

Renovate never renders release notes in update PRs for `score_process` and `score_platform`, while it does for every other SCORE module (e.g. `score_docs_as_code`).

The reason is non-obvious. Renovate's `bazel` datasource does **not** read the `repository` field from `metadata.json`. It derives a module's `sourceUrl` **only** from the `homepage` field. These two modules used GitHub **Pages** URLs as their homepage:

- `score_process` → `https://eclipse-score.github.io/process_description`
- `score_platform` → `https://eclipse-score.github.io/score/`

Renovate's GitHub changelog source only accepts hosts that are `github.com` (or a GitHub-Enterprise `*.github.com`). A `*.github.io` host is rejected, which is visible in the Renovate debug logs:

```
DEBUG: Fetching changelog: https://eclipse-score.github.io/process_description (1.5.4 -> 2.0.1)
DEBUG: Repository URL does not match any known github hosts - skipping changelog retrieval
       { "manager": "bazel-module", "packageName": "score_process",
         "sourceUrl": "https://eclipse-score.github.io/process_description" }
```

As a result, changelog retrieval is skipped entirely and consumers get update PRs with no release notes (e.g. baselibs #339).

## What

Point `homepage` at the GitHub repository URL for both modules, matching the `repository` field already present in each `metadata.json` and consistent with every other module in this registry (37 of 39 already use `https://github.com/eclipse-score/<repo>`).

This is the minimal, data-only change that makes Renovate resolve a valid `github.com` sourceUrl so it can fetch release notes. No registry tooling changes are required — `registry_manager` never writes `homepage`, so this field is static per-module data.

## Changes

- `modules/score_process/metadata.json` — `homepage` → `https://github.com/eclipse-score/process_description`
- `modules/score_platform/metadata.json` — `homepage` → `https://github.com/eclipse-score/score`
