### PR TITLE
feat!: yank score_devcontainer 1.9.2

### DIFF
--- a/modules/score_devcontainer/metadata.json
+++ b/modules/score_devcontainer/metadata.json
@@ -14,5 +14,7 @@
         "1.6.0",
         "1.5.0"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "1.9.2": "score_devcontainer 1.9.2 has been yanked. Please use a different version."
+    }
 }


### PR DESCRIPTION
## Summary

- Yank `score_devcontainer` 1.9.2 from the registry.

## Reason

- `devcontainer` 1.9.2 was removed

## Impact

Prevents new dependency resolutions from selecting the yanked release. Existing users will experience problems - but they already do as the URL points to a 404 page.
